### PR TITLE
Fix naming disparity between `toml` & `from_toml`

### DIFF
--- a/src/Configurations.jl
+++ b/src/Configurations.jl
@@ -1,6 +1,6 @@
 module Configurations
 
-export @option, from_dict, from_kwargs, from_toml, to_dict, toml
+export @option, from_dict, from_kwargs, from_toml, to_dict, to_toml
 
 using OrderedCollections
 using MatchCore
@@ -119,16 +119,16 @@ end
 
 Convert an instance `x` of option type to TOML and write it to `String`. See also `TOML.print`.
 """
-function toml(x; sorted=false, by=identity)
-    return sprint(toml, x)
+function to_toml(x; sorted=false, by=identity)
+    return sprint(to_toml, x)
 end
 
-function toml(io::IO, x; sorted=false, by=identity)
-    return toml(toml_convert(typeof(x)), io, x; sorted=sorted, by=by)
+function to_toml(io::IO, x; sorted=false, by=identity)
+    return to_toml(toml_convert(typeof(x)), io, x; sorted=sorted, by=by)
 end
 
-function toml(filename::String, x; sorted=false, by=identity)
-    return toml(toml_convert(typeof(x)), filename, x; sorted=sorted, by=by)
+function to_toml(filename::String, x; sorted=false, by=identity)
+    return to_toml(toml_convert(typeof(x)), filename, x; sorted=sorted, by=by)
 end
 
 """
@@ -136,9 +136,9 @@ end
 
 Convert an instance `option` of option type to TOML and write it to `filename`. See also `TOML.print`.
 """
-function toml(f, filename::String, x; sorted=false, by=identity)
+function to_toml(f, filename::String, x; sorted=false, by=identity)
     open(filename, "w+") do io
-        toml(f, io, x; sorted=sorted, by=by)
+        to_toml(f, io, x; sorted=sorted, by=by)
     end
 end
 
@@ -147,7 +147,7 @@ end
 
 Convert an instance `option` of option type to TOML and write it to `IO`. See also `TOML.print`.
 """
-function toml(f, io::IO, x; sorted=false, by=identity)
+function to_toml(f, io::IO, x; sorted=false, by=identity)
     return TOML.print(f, io, to_dict(x); sorted=sorted, by=by)
 end
 
@@ -1023,7 +1023,7 @@ end
 function codegen_show_toml_mime(x::OptionDef)
     :(
         function Base.show(io::IO, ::MIME"application/toml", x::$(x.name))
-            return print(io, toml(x))
+            return print(io, to_toml(x))
         end
     )
 end

--- a/src/Configurations.jl
+++ b/src/Configurations.jl
@@ -151,6 +151,8 @@ function to_toml(f, io::IO, x; sorted=false, by=identity)
     return TOML.print(f, io, to_dict(x); sorted=sorted, by=by)
 end
 
+@deprecate toml to_toml
+
 """
     dictionalize(x)
 

--- a/src/Configurations.jl
+++ b/src/Configurations.jl
@@ -115,7 +115,7 @@ function to_dict(x)
 end
 
 """
-    toml(x; sorted=false, by=identity)
+    to_toml(x; sorted=false, by=identity)
 
 Convert an instance `x` of option type to TOML and write it to `String`. See also `TOML.print`.
 """
@@ -132,7 +132,7 @@ function to_toml(filename::String, x; sorted=false, by=identity)
 end
 
 """
-    toml([to_toml::Function], filename::String, option; sorted=false, by=identity)
+    to_toml([f::Function], filename::String, option; sorted=false, by=identity)
 
 Convert an instance `option` of option type to TOML and write it to `filename`. See also `TOML.print`.
 """
@@ -143,7 +143,7 @@ function to_toml(f, filename::String, x; sorted=false, by=identity)
 end
 
 """
-    toml([toml::Function], io::IO, option; sorted=false, by=identity)
+    to_toml([f::Function], io::IO, option; sorted=false, by=identity)
 
 Convert an instance `option` of option type to TOML and write it to `IO`. See also `TOML.print`.
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,8 +46,13 @@ end
 @testset "to_dict" begin
     @test_throws ErrorException to_dict("aaa")
     @test to_dict(option) == dict1
-    @test to_toml(option) == "float = 0.33\n\n[opt]\nname = \"Roger\"\nint = 2\n"
     @test to_dict(from_dict(OptionB, dict2)) == dict2
+end
+
+@testset "to_toml" begin
+    @test to_toml(option) == "float = 0.33\n\n[opt]\nname = \"Roger\"\nint = 2\n"
+    to_toml("test.toml", option)
+    @test read("test.toml", String) == "float = 0.33\n\n[opt]\nname = \"Roger\"\nint = 2\n"
 end
 
 @testset "default reflection" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Configurations
-using Configurations: OptionDef, to_dict, toml, from_kwargs, from_dict, alias,
+using Configurations: OptionDef, to_dict, to_toml, from_kwargs, from_dict, alias,
     from_toml, no_default, field_defaults, field_default, field_alias, field_aliases,
     option_print, resolve_defaults, PartialDefault
 using OrderedCollections
@@ -46,7 +46,7 @@ end
 @testset "to_dict" begin
     @test_throws ErrorException to_dict("aaa")
     @test to_dict(option) == dict1
-    @test toml(option) == "float = 0.33\n\n[opt]\nname = \"Roger\"\nint = 2\n"
+    @test to_toml(option) == "float = 0.33\n\n[opt]\nname = \"Roger\"\nint = 2\n"
     @test to_dict(from_dict(OptionB, dict2)) == dict2
 end
 


### PR DESCRIPTION
Closes #10 