### PR TITLE
Julia 1.0 compat

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         version:
           - '1'
+          - '1.0'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Crayons = "4.0"
 ExproniconLite = "0.6"
 OrderedCollections = "1.3"
 TOML = "1"
-julia = "1.3"
+julia = "1"
 
 [extras]
 Expronicon = "6b7a57c9-7cc1-4fdf-b7f5-e857abae3636"


### PR DESCRIPTION
After https://github.com/Roger-luo/ExproniconLite.jl/pull/2, this package is already compatible with Julia 1.0. I changed the config bound to `"1"`, and after https://github.com/Roger-luo/ExproniconLite.jl/pull/2 is released, Julia's package manager will automatically make sure that 1.0 users get the working combination of packages.

Tests on 1.0 will fail right now, because https://github.com/Roger-luo/ExproniconLite.jl/pull/2 is not yet released, so the dependency cannot be resolved.