### PR TITLE
fix `from_dict` which does not care about keyword arguments as expected

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -26,7 +26,7 @@ OptionA(;
 """
 function from_dict(::Type{T}, d::AbstractDict{String}; kw...) where T
     # override dict values
-    from_underscore_kwargs!(deepcopy(d), T; kw...)
+    d = from_underscore_kwargs!(deepcopy(d), T; kw...)
     return from_dict_validate(T, d)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -230,7 +230,7 @@ end
 
     @test from_dict(OptionB, d; opt_name = "AAA") == OptionB(;
         opt = OptionA(;
-            name = "Roger",
+            name = "AAA",
             int = 2,
         ),
         float = 0.33,


### PR DESCRIPTION
`from_dict` cannot process keyword arguments to override values given by dict.

It looks like a typo.