### PR TITLE
support reflect type

### DIFF
--- a/src/Configurations.jl
+++ b/src/Configurations.jl
@@ -8,6 +8,7 @@ using OrderedCollections
 
 export no_default,
     Maybe,
+    Reflect,
     # reflection
     field_default,
     # field_alias,

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -91,6 +91,10 @@ end
 function option_m(mod::Module, ex, type_alias=nothing)
     ex = macroexpand(mod, ex)
     def = JLKwStruct(ex, type_alias)
+    has_duplicated_reflect_type(mod, def) && throw(
+        ArgumentError("struct fields contain duplicated `Reflect` type")
+    )
+    add_field_defaults!(mod, def)
     return codegen_option_type(def)
 end
 
@@ -112,6 +116,70 @@ function codegen_option_type(def::JLKwStruct)
         $(codegen_isequal(def))
         nothing
     end
+end
+
+function add_field_defaults!(m::Module, def::JLKwStruct)
+    for field in def.fields
+        if is_reflect_type_expr(m, field.type)
+            field.default = Reflect()
+        elseif is_maybe_type_expr(m, field.type) && field.default === no_default
+            field.default = nothing
+        end
+    end
+    return def
+end
+
+function has_duplicated_reflect_type(m::Module, def::JLKwStruct)
+    has_reflect_type = false
+    for field in def.fields
+        if is_reflect_type_expr(m, field.type)
+            has_reflect_type && return true
+            has_reflect_type = true
+        end
+    end
+    return false
+end
+
+function is_reflect_type_expr(m::Module, @nospecialize(ex))
+    if isdefined(m, :Reflect)
+        ex === :Reflect && return true
+    end
+    # no need to check definition
+    ex == Reflect && return true
+    ex == GlobalRef(Configurations, :Reflect) && return true
+    ex == :($Configurations.Reflect) && return true
+    ex == :($Configurations.$Reflect) && return true
+    ex == :(Configurations.$Reflect) && return true
+    if isdefined(m, :Configurations)
+        ex == :(Configurations.Reflect) && return true
+    end
+    return false
+end
+
+function is_maybe_type_expr(m::Module, @nospecialize(ex))
+    if isdefined(m, :Maybe)
+        return _is_maybe_type_expr(ex)
+    end
+
+    # no need to check definition
+    ex isa Type && ex <: Maybe && return true
+    if ex isa GlobalRef && ex.mod === Configurations
+        return _is_maybe_type_expr(ex)
+    end
+
+    ex isa Expr || return false
+    ex.head === :. || return false
+    if ex.args[1] === Configurations || ex.args[1] === :Configurations
+        return false
+    end
+    return _is_maybe_type_expr(ex.args[2])
+end
+
+function _is_maybe_type_expr(@nospecialize(ex))
+    ex === :Maybe && return true
+    ex isa Expr || return false
+    ex.head === :curly && ex.args[1] === :Maybe && return true
+    return false
 end
 
 """

--- a/src/serialize.jl
+++ b/src/serialize.jl
@@ -134,6 +134,7 @@ function _option_to_dict(x, option::ToDictOption)
     for name in fieldnames(T)
         type = fieldtype(T, name)
         value = getfield(x, name)
+        name_str = string(name)
         if option.exclude_nothing && value === nothing
             continue
         end
@@ -141,23 +142,55 @@ function _option_to_dict(x, option::ToDictOption)
         if option.include_defaults || value != field_default(T, name)
             field_dict = to_dict(T, value, option)
 
-            # always add an alias if it's a Union
+            # 1. option type contains field of type Reflect
+            # 2. option type contains field of Union{options...}
+            # 3. other types
+            #
+            # NOTE:
+            # we always add an alias if it's a Union
             # of multiple option types
-            if is_option(value) && is_union_of_multiple_options(type)
+            if type === Reflect
+                # we don't implement this via `to_dict`
+                # because we want it error when `Reflect`
+                # is used as a normal type
+                # `Reflect` should be only used to denote
+                # a field contains the type info as a `String`.
+                d[name_str] = full_typename(T)
+            elseif is_option(value) && is_union_of_multiple_options(type)
+                if contains_reflect_type(typeof(value))
+                    d[name_str] = field_dict
+                    continue
+                end
+
                 if type_alias(typeof(value)) === nothing
                     error("please define an alias for option type $(typeof(value))")
                 end
 
-                d[string(name)] = OrderedDict{String, Any}(
+                d[name_str] = OrderedDict{String, Any}(
                     type_alias(typeof(value)) => field_dict,
                 )
             else
-                d[string(name)] = field_dict
+                d[name_str] = field_dict
             end
         end
     end
     return d
 end
+
+# NOTE: copied from JLD
+# https://github.com/JuliaIO/JLD.jl/blob/83ea0c5ef7293c78d7d9c8ffdf9ede599b54dc4c/src/JLD00.jl#L991
+# we only have DataType to serialize
+function full_typename(jltype::DataType)
+    tname = string(jltype.name.module, ".", jltype.name.name)
+    if isempty(jltype.parameters)
+        return tname
+    else
+        params_str = join([full_typename(x) for x in jltype.parameters], ",")
+        return string(tname, "{", params_str, "}")
+    end
+end
+
+contains_reflect_type(::Type{T}) where T = Reflect in fieldtypes(T)
 
 function is_union_of_multiple_options(::Type{T}) where T
     T isa Union || return false
@@ -168,6 +201,12 @@ function is_union_of_multiple_options(::Type{T}) where T
     return is_option_maybe(T.a) && is_option_maybe(T.b)
 end
 
+"""
+    is_option_maybe(::Type{T}) where T
+
+`T` is an option struct or if `T` is an union, one of the types
+is an option struct.
+"""
 function is_option_maybe(::Type{T}) where T
     is_option(T) && return true
     T isa Union || return false

--- a/src/types.jl
+++ b/src/types.jl
@@ -19,6 +19,33 @@ function Base.show(io::IO, x::PartialDefault)
 end
 
 """
+    Reflect
+
+Placeholder type for reflected type string.
+
+# Example
+
+the following option struct
+
+```julia
+@option struct MyOption
+    type::Reflect
+    name::String = "Sam"
+end
+```
+
+would be equivalent to
+
+```toml
+type = "MyOption"
+name = "Sam"
+```
+
+this is useful for defining list of different types etc.
+"""
+struct Reflect end
+
+"""
     create(::Type{T}; kwargs...) where T
     
 Create an instance of option type `T` from `kwargs`. Similar


### PR DESCRIPTION
this PR:

- fix #48 
- support auto default value for `Maybe` since we are using this to denote optional fields, if the default value is not specified, it should have default value `nothing` by definition
- support auto default value for `Reflect` since it doesn't make sense to manually type `Reflect` twice