### PR TITLE
Feature issue 68

### DIFF
--- a/src/Configurations.jl
+++ b/src/Configurations.jl
@@ -33,6 +33,7 @@ export @option,
     DuplicatedFieldError,
     DuplicatedAliasError,
     InvalidKeyError,
+    FieldTypeConversionError,
     TOMLStyle,
     YAMLStyle,
     JSONStyle

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -54,3 +54,27 @@ function Base.showerror(io::IO, err::DuplicatedFieldError)
     printstyled(io, err.type; color=:green)
     return print(io, " and its sub-fields")
 end
+
+"""
+    FieldTypeConversionError(type, fieldname, fieldtype, optiontype)
+
+A conversion from `type` to `fieldtype` belonging to `fieldname` in an `optiontype` failed.
+"""
+struct FieldTypeConversionError <: Exception
+    type
+    fieldname::Symbol
+    fieldtype
+    optiontype
+end
+
+function Base.showerror(io::IO, err::FieldTypeConversionError)
+    print(io, "FieldTypeConversionError: conversion from ")
+    printstyled(io, err.type; color=:red)
+    print(io, " to type ")
+    printstyled(io, err.fieldtype; color=:green)
+    print(io, " for field ")
+    printstyled(io, err.fieldname; color=:light_blue)
+    print(io, " in type ")
+    printstyled(io, err.optiontype; color=:green)
+    return print(io, " failed")
+end

--- a/src/from_dict.jl
+++ b/src/from_dict.jl
@@ -100,17 +100,19 @@ struct OptionField{name} end
 OptionField(name::Symbol) = OptionField{name}()
 
 """
-    _from_dict_errorhandled(::Type{OptionType}, optionfield::OptionField{f_name}, ::Type{T}, x)
+    from_dict(::Type{OptionType}, ::OptionField{f_name}, ::Type{T}, x) where {OptionType, f_name, T}
 
-Raise `FieldTypeConversionError`s errors if `from_dict` or `Base.convert` raise exceptions
+For option type `OptionType`, convert the object `x` to the field type `T` and assign it to the field
+`f_name`.
+Raise `FieldTypeConversionError`s errors if `Base.convert` raises exception
 ```
 ERROR: MethodError: Cannot `convert` an object of type ...
 ```
 """
-function _from_dict_errorhandled(::Type{OptionType}, optionfield::OptionField{f_name}, ::Type{T}, x
-        ) where {OptionType,f_name, T}
+function from_dict(::Type{OptionType}, optionfield::OptionField{f_name}, ::Type{T}, x
+      ) where {OptionType,f_name,T}
     try
-        return from_dict(OptionType, optionfield, T, x)
+        return from_dict(OptionType, T, x)
     catch err
         if err isa MethodError && err.f === convert
             throw(FieldTypeConversionError(typeof(x), f_name, T, OptionType))
@@ -118,16 +120,6 @@ function _from_dict_errorhandled(::Type{OptionType}, optionfield::OptionField{f_
             throw(err)
         end
     end
-end
-
-"""
-    from_dict(::Type{OptionType}, ::OptionField{f_name}, ::Type{T}, x) where {OptionType, f_name, T}
-
-For option type `OptionType`, convert the object `x` to the field type `T` and assign it to the field
-`f_name`.
-"""
-function from_dict(::Type{OptionType}, ::OptionField, ::Type{T}, x) where {OptionType,T}
-    return from_dict(OptionType, T, x)
 end
 
 function from_dict(
@@ -182,7 +174,7 @@ end
 function from_dict_union_type_dynamic(
     ::Type{OptionType}, of::OptionField{f_name}, ::Type{FieldType}, value
 ) where {OptionType,f_name,FieldType}
-    FieldType isa Union || return _from_dict_errorhandled(OptionType, of, FieldType, value)
+    FieldType isa Union || return from_dict(OptionType, of, FieldType, value)
     assert_duplicated_alias_union(FieldType)
 
     types = Base.uniontypes(FieldType)
@@ -190,7 +182,7 @@ function from_dict_union_type_dynamic(
         value === nothing && return nothing # happy path
         types = filter(x -> x !== Nothing, types)
         if length(types) == 1
-            return _from_dict_errorhandled(OptionType, of, types[1], value)
+            return from_dict(OptionType, of, types[1], value)
         end
     end
 
@@ -227,7 +219,7 @@ function from_dict_union_type_dynamic(
             end
         else
             try
-                return _from_dict_errorhandled(OptionType, of, T, value)
+                return from_dict(OptionType, of, T, value)
             catch
                 continue
             end
@@ -361,7 +353,7 @@ function from_dict_generated(
         end
     else
         quote
-            $Configurations._from_dict_errorhandled($option_type, $of, $f_type, $field_value)
+            $Configurations.from_dict($option_type, $of, $f_type, $field_value)
         end
     end
 end

--- a/src/from_dict.jl
+++ b/src/from_dict.jl
@@ -112,6 +112,8 @@ function from_dict(::Type{OptionType}, ::OptionField{f_name}, ::Type{T}, x
     catch err
         if err isa MethodError && err.f === convert
             throw(FieldTypeConversionError(typeof(x), f_name, T, OptionType))
+        else 
+            throw(err)
         end
     end
 end

--- a/src/from_dict.jl
+++ b/src/from_dict.jl
@@ -105,8 +105,15 @@ OptionField(name::Symbol) = OptionField{name}()
 For option type `OptionType`, convert the object `x` to the field type `T` and assign it to the field
 `f_name`.
 """
-function from_dict(::Type{OptionType}, ::OptionField, ::Type{T}, x) where {OptionType,T}
-    return from_dict(OptionType, T, x)
+function from_dict(::Type{OptionType}, ::OptionField{f_name}, ::Type{T}, x
+        ) where {OptionType,f_name, T}
+    try
+        return from_dict(OptionType, T, x)
+    catch err
+        if err isa MethodError && err.f === convert
+            throw(FieldTypeConversionError(typeof(x), f_name, T, OptionType))
+        end
+    end
 end
 
 function from_dict(

--- a/test/test_basic.jl
+++ b/test/test_basic.jl
@@ -295,7 +295,7 @@ end
         ),
     )
 
-    @test_throws MethodError from_dict(Ion, d)
+    @test_throws FieldTypeConversionError from_dict(Ion, d)
 
     function Configurations.convert_to_option(
         ::Type{Julia}, ::Type{Dict{VersionNumber,String}}, x::Dict{String,String}
@@ -531,6 +531,15 @@ end
 
 @testset "duplicated field check" begin
     @test_throws Configurations.DuplicatedFieldError field_keywords(DuplicatedFields)
+end
+
+@option struct WrongFieldTypeConversion
+    str::String
+end
+
+@testset "catch field type conversion error" begin
+    d = Dict("str"=>:symbol)
+    @test_throws FieldTypeConversionError from_dict(WrongFieldTypeConversion, d)
 end
 
 @test_throws ErrorException Configurations.create(Float64; name="abc")

--- a/test/test_basic.jl
+++ b/test/test_basic.jl
@@ -83,6 +83,7 @@ end
     showerror(stdout, InvalidKeyError(:name, [Symbol(:a, idx) for idx in 1:10]))
     showerror(stdout, DuplicatedFieldError(:name, OptionA))
     showerror(stdout, DuplicatedAliasError("alias"))
+    showerror(stdout, FieldTypeConversionError(Float64, :field, String, OptionA))
 end
 
 @testset "options" begin

--- a/test/test_basic.jl
+++ b/test/test_basic.jl
@@ -295,6 +295,7 @@ end
         ),
     )
 
+    # @test_throws MethodError from_dict(Ion, d)
     @test_throws FieldTypeConversionError from_dict(Ion, d)
 
     function Configurations.convert_to_option(
@@ -531,15 +532,6 @@ end
 
 @testset "duplicated field check" begin
     @test_throws Configurations.DuplicatedFieldError field_keywords(DuplicatedFields)
-end
-
-@option struct WrongFieldTypeConversion
-    str::String
-end
-
-@testset "catch field type conversion error" begin
-    d = Dict("str"=>:symbol)
-    @test_throws FieldTypeConversionError from_dict(WrongFieldTypeConversion, d)
 end
 
 @test_throws ErrorException Configurations.create(Float64; name="abc")

--- a/test/test_from_dict.jl
+++ b/test/test_from_dict.jl
@@ -67,7 +67,7 @@ end
 end
 
 # overload from_dict for field str such that it produces a MethodError 'convert failed' error
-# intentionally which should be caught by FieldTypeConversionError exception
+# this won't be caught by FieldTypeConversion error!
 function Configurations.from_dict(::Type{FieldTypeConversionStruct_errornous_from_dict_overload}, 
         ::OptionField{:str}, ::Type{T}, x) where {T}
     return convert(T, Symbol(x)) # will fail, because T will be String
@@ -149,7 +149,7 @@ end
         d = Dict("str"=>:symbol)
         @test_throws FieldTypeConversionError from_dict(FieldTypeConversionStruct, d)
         d = Dict("str"=>"symbol")
-        @test_throws FieldTypeConversionError from_dict(
+        @test_throws MethodError from_dict(
                         FieldTypeConversionStruct_errornous_from_dict_overload, d)
     end
 end

--- a/test/test_from_dict.jl
+++ b/test/test_from_dict.jl
@@ -69,8 +69,9 @@ end
 # overload from_dict for field str such that it produces a MethodError 'convert failed' error
 # this won't be caught by FieldTypeConversion error!
 function Configurations.from_dict(::Type{FieldTypeConversionStruct_errornous_from_dict_overload}, 
-        ::OptionField{:str}, ::Type{T}, x) where {T}
-    return convert(T, Symbol(x)) # will fail, because T will be String
+        ::Type{T}, x) where {T}
+    @assert false "Some artificial conversion error"
+    return
 end
 
 @testset "from_dict" begin
@@ -149,8 +150,7 @@ end
         d = Dict("str"=>:symbol)
         @test_throws FieldTypeConversionError from_dict(FieldTypeConversionStruct, d)
         d = Dict("str"=>"symbol")
-        @test_throws MethodError from_dict(
-                        FieldTypeConversionStruct_errornous_from_dict_overload, d)
+        @test_throws Exception from_dict(FieldTypeConversionStruct_errornous_from_dict_overload, d)
     end
 end
 


### PR DESCRIPTION
# MWE

```julia
julia> @option struct MyType
          str::String
       end

julia> fd = Dict("str"=>:abc)
Dict{String, Symbol} with 1 entry:
  "str" => :abc

julia> from_dict(MyType, fd)
ERROR: FieldTypeConversionError: conversion from Symbol to type String for field str in type MyType failed
```