### PR TITLE
Interpolate `Reflect` in `from_dict_generated`

### DIFF
--- a/src/from_dict.jl
+++ b/src/from_dict.jl
@@ -357,14 +357,14 @@ function from_dict_generated(
             quote
                 $Configurations.parse_jltype($field_value, $alias_map) <: $option_type ||
                     throw(ArgumentError($msg * " $($field_value)"))
-                Reflect()
+                $Reflect()
             end
         else
             quote
                 $field_value == $alias ||
                     $Configurations.parse_jltype($field_value, $alias_map) <: $option_type ||
                     throw(ArgumentError($msg * " $($field_value)"))
-                Reflect()
+                $Reflect()
             end
         end
     else


### PR DESCRIPTION
Currently, defining options in a module without making `Reflect` explicitly available in the scope breaks `from_dict` due to the lack of interpolation of `Reflect` in https://github.com/Roger-luo/Configurations.jl/blob/1dedfb37d5ed61aa45e62e1fa4230859877feddd/src/from_dict.jl#L338-L375