### PR TITLE
Fix package downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,5 +86,5 @@ MIT License
 [docs-stable-url]: https://Roger-luo.github.io/Configurations.jl/stable
 [aqua-img]: https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg
 [aqua-url]: https://github.com/JuliaTesting/Aqua.jl
-[downloads-img]:https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/Configurations
-[downloads-url]:https://pkgs.genieframework.com?packages=Configurations
+[downloads-img]:https://img.shields.io/badge/dynamic/json?url=http%3A%2F%2Fjuliapkgstats.com%2Fapi%2Fv1%2Fmonthly_downloads%2FConfigurations&query=total_requests&suffix=%2Fmonth&label=Downloads
+[downloads-url]:https://juliapkgstats.com/pkg/Configurations


### PR DESCRIPTION
Fixed the download count badge using https://juliapkgstats.com/.

This PR:
- Replaces the broken badge with a new badge that uses the new API

Please review and provide any feedback. Thanks for considering this PR!
